### PR TITLE
Fix:projects, finds, groups, fields 수정

### DIFF
--- a/tingleProject/finds/serializers.py
+++ b/tingleProject/finds/serializers.py
@@ -3,15 +3,11 @@ from my.models import MyProfile
 
 # 사용자 리스트
 class FindsUserListSerializer(serializers.ModelSerializer):
-    total_user = serializers.SerializerMethodField()
     is_bookmarked = serializers.SerializerMethodField()
 
     class Meta:
        model = MyProfile
-       fields = ['id', 'name', 'job', 'total_user', 'is_bookmarked']
-
-    def get_total_user(self, obj):
-        return MyProfile.objects.exclude(user=self.context['request'].user).count()
+       fields = ['id', 'name', 'job', 'is_bookmarked']
 
     def get_is_bookmarked(self, obj):
         user = self.context['request'].user
@@ -27,5 +23,5 @@ class FindUserDetailSerializer(serializers.ModelSerializer):
     
     def get_is_bookmarked(self, obj):
         user = self.context['request'].user
-        return obj.bookmarks_by.filter(user=user).exist()
+        return obj.bookmarks_by.filter(user=user).exists()
 

--- a/tingleProject/finds/views.py
+++ b/tingleProject/finds/views.py
@@ -20,6 +20,15 @@ class FindUserViewSet(viewsets.ReadOnlyModelViewSet):
             return FindUserDetailSerializer
         return FindsUserListSerializer
     
+    def list(self, request, *args, **kwargs):
+        queryset = self.get_queryset()
+        serializer = self.get_serializer(queryset, many=True, context={'request': request})
+        total_users = queryset.count()
+        return Response({
+            "total_users": total_users,
+            "profiles": serializer.data
+        })
+    
     # 그룹추가
     @action(detail=True, methods=['post'])
     def add_to_team(self, request, pk=None):

--- a/tingleProject/groups/serializers.py
+++ b/tingleProject/groups/serializers.py
@@ -9,12 +9,12 @@ User = get_user_model()
 class UserSerializer(ModelSerializer):
     class Meta:
         model = User
-        fields = ['id', 'username', 'email']
+        fields = ['username', 'email']
 
 class ProjectSerializer(ModelSerializer):
     class Meta:
         model = Post
-        fields = ['id', 'title', 'project_type', 'project_field']
+        fields = ['id', 'title', 'project_type', 'project_field', 'target']
 
 class BaseTeamProjectInfoSerializer(ModelSerializer):
     project_type = SerializerMethodField()
@@ -41,17 +41,18 @@ class TeamMemberSerializer(ModelSerializer):
     
     class Meta:
         model = TeamMember
-        fields = ['id', 'team', 'user', 'user_id']
-        read_only_fields = ['id', 'team']
+        fields = ['user', 'user_id']
+        # read_only_fields = ['id', 'team'] 
+        # id, team 필드 제거 
 
 
 class TeamSerializer(BaseTeamProjectInfoSerializer):
     project = ProjectSerializer(read_only=True)
-    project_id = serializers.PrimaryKeyRelatedField(
-        queryset=Post.objects.all(),
-        source='project',
-        write_only=True  # 요청 시만 사용 (입력 전용)
-    )
+    # project_id = serializers.PrimaryKeyRelatedField(
+    #     queryset=Post.objects.all(),
+    #     source='project',
+    #     write_only=True  # 요청 시만 사용 (입력 전용)
+    # ) 응답에서 중복으로 나오니까 제거 
 
     target = SerializerMethodField()
     members = TeamMemberSerializer(many=True, read_only=True)  # 중첩 serializer 사용
@@ -59,23 +60,24 @@ class TeamSerializer(BaseTeamProjectInfoSerializer):
 
     class Meta:
         model = Team # Group 모델을 참조
-        fields = ['id', 'name', 'project', 'project_id', 'project_type', 'project_field', 'target', 'part', 'description', 'members', 'progress', 'created_by']
+        fields = ['id', 'name', 'project', 'part', 'description', 'members', 'progress', 'created_by']
+        # 'project_id', 'project_type', 'project_field', 'target' 제거
         read_only_fields = ['id', 'status', 'created_by'] 
 
-    
-    def get_target(self, obj):
-        if obj.project:
-            return obj.project.target
-        return None
-
+    # target 제거
+    # def get_target(self, obj):
+    #     if obj.project:
+    #         return obj.project.target
+    #     return None 
 
 
 class TeamListSerializer(BaseTeamProjectInfoSerializer):
     project = ProjectSerializer(read_only=True)
+    created_by = serializers.CharField(source='created_by.username', read_only=True)
 
     class Meta:
         model = Team
-        fields = ['id', 'name', 'project', 'project_type', 'project_field', 'created_by']
+        fields = ['id', 'name', 'project', 'created_by']
         read_only_fields = ['id', 'status']
 
 #댓글
@@ -95,5 +97,5 @@ class TeamBookmarkSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = TeamBookmark
-        fields = ['id', 'user', 'team', 'team_id']
-        read_only_fields = ['id', 'user', 'team']
+        fields = ['team_id']
+        # read_only_fields = ['id', 'user', 'team']

--- a/tingleProject/groups/views.py
+++ b/tingleProject/groups/views.py
@@ -1,6 +1,6 @@
 from django.shortcuts import render, get_object_or_404
-from .serializers import TeamSerializer, TeamListSerializer, TeamMemberSerializer, CommentSerializer, TeamBookmarkSerializer
-from .models import Team, TeamMember, Comment, TeamBookmark
+from .serializers import *
+from .models import *
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -76,7 +76,6 @@ class TeamViewSet(ModelViewSet):
 
         return Response({'detail': '진행률이 수정되었습니다.'}, status=status.HTTP_200_OK)
         
-
 
 class TeamMemberViewSet(ModelViewSet):
     queryset = TeamMember.objects.all()

--- a/tingleProject/projects/serializers.py
+++ b/tingleProject/projects/serializers.py
@@ -1,9 +1,10 @@
 from rest_framework.serializers import ModelSerializer
 from rest_framework import serializers
 from .models import Post, Comment, ProjectBookmark
+from accounts.serializers import UserSerializer
 
 class PostSerializer(ModelSerializer):
-    
+    created_by = serializers.CharField(source='created_by.username', read_only=True)
     class Meta:
         model = Post
         fields = '__all__'
@@ -18,13 +19,15 @@ class CommentSerializer(ModelSerializer):
 
 
 class ProjectBookmarkSerializer(ModelSerializer):
+    post = serializers.PrimaryKeyRelatedField(read_only=True)
+
     post_id = serializers.PrimaryKeyRelatedField(
         queryset=Post.objects.all(),
-        source='post',        # 내부에서는 post 필드로 매핑
-        write_only=True       # 입력 시에만 쓰고, 출력에는 안 보임
+        source='post',
+        write_only=True
     )
+
     class Meta:
         model = ProjectBookmark
-        fields = ['id', 'user', 'post', 'post_id']
-        read_only_fields = ['id', 'user', 'post']
+        fields = ['post', 'post_id']
 

--- a/tingleProject/projects/views.py
+++ b/tingleProject/projects/views.py
@@ -12,7 +12,8 @@ class PostViewSet(ModelViewSet):
     serializer_class = PostSerializer
 
     def get_queryset(self):
-        queryset = Post.objects.filter(created_by = self.request.user)
+        # queryset = Post.objects.filter(created_by = self.request.user)
+        queryset = Post.objects.filter() # 전체 가져오기 
         status = self.request.query_params.get('status')
         if status:
             queryset = queryset.filter(status=status)

--- a/tingleProject/requirements.txt
+++ b/tingleProject/requirements.txt
@@ -1,5 +1,5 @@
 asgiref==3.8.1
-Django==5.2.3
+Django==4.2.23
 django-cors-headers==4.7.0
 djangorestframework==3.16.0
 djangorestframework-camel-case==1.4.2


### PR DESCRIPTION
Fix:projects, finds, groups, fields 수정
response에서 숫자로 그냥 써져 있던 부분들 (user:1) -> 의미를 명확하게 하기 위해서 name으로 바꿈
response에서 쓸모없는 중복필드들 삭제 
